### PR TITLE
Report ASCII even when escape sequences are present

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,7 @@ impl UniversalDetector {
         } else {
             if self.m_got_data {
                 match self.m_input_state {
+                    enums::InputState::EscAscii |
                     enums::InputState::PureAscii => {
                         self.m_detected_charset = "ascii".to_string();
                         self.m_detected_confidence = 1.0;
@@ -325,7 +326,6 @@ impl UniversalDetector {
                                 .get_language();
                         }
                     }
-                    _ => unreachable!(),
                 }
             } else {
             }

--- a/tests/data/ascii/ascii_with_esc.txt
+++ b/tests/data/ascii/ascii_with_esc.txt
@@ -1,0 +1,4 @@
+This is an ASCII TEST.
+We still want chardet to detect it as ASCII, even with the presence of
+an escape character: 
+Or with the HZ encoding escape sequence: ~{

--- a/tests/run_test.rs
+++ b/tests/run_test.rs
@@ -7,6 +7,7 @@ const TEST_TABLE:&[(&str, &str, f32, &str)] = &[
     ("tests/data/ascii/howto.diveintomark.org.xml","ascii", 0.99, ""),
     ("tests/data/ascii/_chromium_iso-8859-1_with_no_encoding_specified.html","ascii", 0.99, ""),
     ("tests/data/ascii/_mozilla_bug638318_text.html","ascii", 0.99, ""),
+    ("tests/data/ascii/ascii_with_esc.txt","ascii", 0.99, ""),
     ("tests/data/Big5/0804.blogspot.com.xml","Big5", 0.99, "Chinese"),
     ("tests/data/Big5/blog.worren.net.xml","Big5", 0.99, "Chinese"),
     ("tests/data/Big5/carbonxiv.blogspot.com.xml","Big5", 0.99, "Chinese"),


### PR DESCRIPTION
This fixes a bug where detecting the charset of ASCII files that include escape sequences run into `unreachable!`.

Based on uchardet's implementation:
https://github.com/BYVoid/uchardet/blob/e6be22803691b60a275176fcf7d89315e1c76d8d/src/nsUniversalDetector.cpp#L247-L252